### PR TITLE
Support SOME/IP TP

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ classifiers =
 [options]
 zip_safe = true
 install_requires =
+    bitstruct
 package_dir =
     = src
 packages = find:


### PR DESCRIPTION
Hi @afflux, 

This change adds SOME/IP TP support by transparently segmenting SOME/IP messages over a certain payload length by using the new `send_msg` method.

Conversely, on the receiving end, it assembles SOME/IP TP segments into SOME/IP messages.

Please let me know what you think.