### PR TITLE
fix bind_addr assignment for IPv6

### DIFF
--- a/src/someip/sd.py
+++ b/src/someip/sd.py
@@ -244,10 +244,7 @@ class ServiceDiscoveryProtocol(SOMEIPDatagramProtocol):
             if multicast_addr:
                 bind_addr = None
                 if platform.system() == "Linux":  # pragma: nocover
-                    if family == socket.AF_INET or "%" in multicast_addr:
-                        bind_addr = multicast_addr
-                    else:
-                        bind_addr = f"{multicast_addr}%{multicast_interface}"
+                    bind_addr = multicast_addr
             # wrong type in asyncio typeshed, should be optional
             bind_addr = typing.cast(str, bind_addr)
 


### PR DESCRIPTION
As far as I can tell the if statement is not needed with IPv6. It actually fails on my machine with:

```
Traceback (most recent call last):
  File "monitor-sd.py", line 87, in <module>
    main()
  File "monitor-sd.py", line 79, in main
    asyncio.get_event_loop().run_until_complete(
  File "/usr/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "monitor-sd.py", line 22, in run
    trsp_u, trsp_m, protocol = await SDProto.create_endpoints(
  File "/usr/local/lib/python3.8/dist-packages/someip/sd.py", line 380, in create_endpoints
    trsp_m = await cls._create_endpoint(
  File "/usr/local/lib/python3.8/dist-packages/someip/sd.py", line 254, in _create_endpoint
    trsp, _ = await loop.create_datagram_endpoint(
  File "/usr/lib/python3.8/asyncio/base_events.py", line 1265, in create_datagram_endpoint
    infos = await self._ensure_resolved(
  File "/usr/lib/python3.8/asyncio/base_events.py", line 1365, in _ensure_resolved
    return await loop.getaddrinfo(host, port, family=family, type=type,
  File "/usr/lib/python3.8/asyncio/base_events.py", line 825, in getaddrinfo
    return await self.run_in_executor(
  File "/usr/lib/python3.8/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/lib/python3.8/socket.py", line 918, in getaddrinfo
    for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
socket.gaierror: [Errno -2] Name or service not known
```

Some testing:

```
>socket.getaddrinfo("ff14::4:0%eth0.4", 30490)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.8/socket.py", line 918, in getaddrinfo
    for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
socket.gaierror: [Errno -2] Name or service not known

>socket.getaddrinfo("ff14::4:0", 30490)
[(<AddressFamily.AF_INET6: 10>, <SocketKind.SOCK_STREAM: 1>, 6, '', ('ff14::4:0', 30490, 0, 0)), (<AddressFamily.AF_INET6: 10>, <SocketKind.SOCK_DGRAM: 2>, 17, '', ('ff14::4:0', 30490, 0, 0)), (<AddressFamily.AF_INET6: 10>, <SocketKind.SOCK_RAW: 3>, 0, '', ('ff14::4:0', 30490, 0, 0))]
```