### PR TITLE
Fixed issue where the SimpleService stop_announce method would crash

### DIFF
--- a/src/someip/service.py
+++ b/src/someip/service.py
@@ -236,13 +236,13 @@ class SimpleService(sd.SOMEIPDatagramProtocol, sd.ServerServiceListener):
         return prot
 
     def start_announce(self, announcer: sd.ServiceAnnouncer):
-        instance = sd.ServiceInstance(
+        self.service_instance = sd.ServiceInstance(
             self.as_config(), self, announcer, announcer.timings
         )
-        announcer.announce_service(instance)
+        announcer.announce_service(self.service_instance)
 
     def stop_announce(self, announcer: sd.ServiceAnnouncer):
-        announcer.stop_announce_service(self.as_config(), self)
+        announcer.stop_announce_service(self.service_instance)
 
     def stop(self):  # pragma: nocover
         self.transport.close()


### PR DESCRIPTION
I've noticed that calling the `stop_announce` method on the SimpleService class causes the program will crash.

The crash is caused by the `stop_announce` method re-constructing the instance so that when the announcer searches through it's list of services it is announcing it is unable to remove the service instance on this line: 
https://github.com/afflux/pysomeip/blob/master/src/someip/sd.py#L1313

If you simple call the `stop` method of SimpleService this issue is not encountered by SD announcer won't stop announcing the service. 
In in the toos/simpleservice.py file this is circumvented as the entire announcer is stopped before the SimpleService is stopped.

I've made an example of this here: https://github.com/AlwinHughes/pysomeip/blob/demo/tools/simpleservice.py. This demo will crash if it's run with the version of SimpleService that is on the current afflux/master but completes successfully with the changes in this PR.

My proposed solution is to store the service_instance when SimpleService `start_announce` is called. Then when `stop_announce` is called the correct instance can be passed to the announcer. This allows multiple SimpleServices to be announced by the same ServiceAnnouncer and each service to be offered/stopped independent of each other. 

I'm new to contributing to open source projects so please let me know what you think or if I've missed anything.

