### PR TITLE
fixed unit test for simple service stop_announce method 

### DIFF
--- a/src/someip/header.py
+++ b/src/someip/header.py
@@ -161,7 +161,7 @@ payload: {len(self.payload)} bytes"""
         size, builder = cls._parse_header(parsed)
         if len(buf_rest) < size - 8:
             raise IncompleteReadError(
-                f"packet too short, expected {size+4}, got {len(buf)}"
+                f"packet too short, expected {size + 4}, got {len(buf)}"
             )
         payload_b, buf_rest = buf_rest[: size - 8], buf_rest[size - 8 :]
 
@@ -485,12 +485,12 @@ class SOMEIPSDEntry:
 
         if oi1 + no1 > num_options:
             raise ParseError(
-                f"SD entry options_1 ({oi1}:{oi1+no1}) out of range ({num_options})"
+                f"SD entry options_1 ({oi1}:{oi1 + no1}) out of range ({num_options})"
             )
 
         if oi2 + no2 > num_options:
             raise ParseError(
-                f"SD entry options_2 ({oi2}:{oi2+no2}) out of range ({num_options})"
+                f"SD entry options_2 ({oi2}:{oi2 + no2}) out of range ({num_options})"
             )
 
         if sd_type in (SOMEIPSDEntryType.Subscribe, SOMEIPSDEntryType.SubscribeAck):

--- a/src/someip/utils.py
+++ b/src/someip/utils.py
@@ -25,7 +25,8 @@ def log_exceptions(msg="unhandled exception in {__func__}"):
                     return await f(self, *args, **kwargs)
                 except Exception:
                     self.log.exception(
-                        msg.format(__func__=f.__qualname__, *args, **kwargs)
+                        msg.format(__func__=f.__qualname__,
+                                   *args, **kwargs)  # noqa: B026
                     )
 
         else:
@@ -36,7 +37,8 @@ def log_exceptions(msg="unhandled exception in {__func__}"):
                     return f(self, *args, **kwargs)
                 except Exception:
                     self.log.exception(
-                        msg.format(__func__=f.__qualname__, *args, **kwargs)
+                        msg.format(__func__=f.__qualname__,
+                                   *args, **kwargs)  # noqa: B026
                     )
 
         return wrapper

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -10,7 +10,6 @@ import unittest
 import unittest.mock
 from dataclasses import replace
 
-import someip.config as cfg
 import someip.header as hdr
 import someip.sd as sd
 import someip.service as service
@@ -134,12 +133,6 @@ class TestService(unittest.IsolatedAsyncioTestCase):
         self.prot.transport.get_extra_info.side_effect = get_extra_info
 
         self.prot.start_announce(sd)
-
-        ep = hdr.IPv4EndpointOption(
-            ipaddress.IPv4Address(ip),
-            port=port,
-            l4proto=hdr.L4Protocols.UDP,
-        )
 
         self.assertEqual(len(sd.method_calls), 1)
         sd.announce_service.assert_called_once()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -145,15 +145,8 @@ class TestService(unittest.IsolatedAsyncioTestCase):
         sd.announce_service.assert_called_once()
         inst = sd.announce_service.call_args[0][0]
         self.assertEqual(
-            inst.service,
-            cfg.Service(
-                service_id=self.prot.service_id,
-                instance_id=self.prot.instance_id,
-                major_version=self.prot.version_major,
-                minor_version=self.prot.version_minor,
-                options_1=(ep,),
-                eventgroups=frozenset({self.prot.eventgroup.id}),
-            ),
+            inst,
+            self.prot.service_instance
         )
         self.assertEqual(inst.listener, self.prot)
         self.assertEqual(inst.announcer, sd)
@@ -165,15 +158,7 @@ class TestService(unittest.IsolatedAsyncioTestCase):
             sd.method_calls,
             [
                 unittest.mock.call.stop_announce_service(
-                    cfg.Service(
-                        service_id=self.prot.service_id,
-                        instance_id=self.prot.instance_id,
-                        major_version=self.prot.version_major,
-                        minor_version=self.prot.version_minor,
-                        options_1=(ep,),
-                        eventgroups=frozenset({self.prot.eventgroup.id}),
-                    ),
-                    self.prot,
+                    self.prot.service_instance,
                 )
             ],
         )

--- a/tools/find-subscribe.py
+++ b/tools/find-subscribe.py
@@ -85,7 +85,7 @@ def auto_int(s):
 
 def setup_log(fmt="", **kwargs):
     try:
-        import coloredlogs  # type: ignore[import]
+        import coloredlogs  # type: ignore[import-not-found]
         coloredlogs.install(fmt="%(asctime)s,%(msecs)03d " + fmt, **kwargs)
     except ModuleNotFoundError:
         logging.basicConfig(format="%(asctime)s " + fmt, **kwargs)

--- a/tools/get.py
+++ b/tools/get.py
@@ -52,7 +52,7 @@ def auto_int(s):
 
 def setup_log(fmt="", **kwargs):
     try:
-        import coloredlogs  # type: ignore[import]
+        import coloredlogs  # type: ignore[import-not-found]
         coloredlogs.install(fmt="%(asctime)s,%(msecs)03d " + fmt, **kwargs)
     except ModuleNotFoundError:
         logging.basicConfig(format="%(asctime)s " + fmt, **kwargs)

--- a/tools/monitor-sd.py
+++ b/tools/monitor-sd.py
@@ -53,7 +53,7 @@ def auto_int(s):
 
 def setup_log(fmt="", **kwargs):
     try:
-        import coloredlogs  # type: ignore[import]
+        import coloredlogs  # type: ignore[import-not-found]
         coloredlogs.install(fmt="%(asctime)s,%(msecs)03d " + fmt, **kwargs)
     except ModuleNotFoundError:
         logging.basicConfig(format="%(asctime)s " + fmt, **kwargs)

--- a/tools/simpleservice.py
+++ b/tools/simpleservice.py
@@ -95,7 +95,7 @@ async def run(local_addr, multicast_addr, port):
 
 def setup_log(fmt="", **kwargs):
     try:
-        import coloredlogs  # type: ignore[import]
+        import coloredlogs  # type: ignore[import-not-found]
 
         coloredlogs.install(fmt="%(asctime)s,%(msecs)03d " + fmt, **kwargs)
     except ModuleNotFoundError:


### PR DESCRIPTION
I've fixed the unit test for the simple service `stop_announce` method.
This was broken in my last MR (#23) where we switched from passing a `config.Service` to a `ServiceInstance` object to the `ServiceAnnouncer` `announce_service` metho.`  I think this fixes it.

I'm not very familiar with pytest and I don't really follow why the `self.prot` line was needed before but it seems to fail the test now so I've removed it. 

I've also updated the `announce_service` test to check the whole service instance object rather than just the `service_instance.config` object